### PR TITLE
Initializing the metric as a Module child will place it on the correct device

### DIFF
--- a/src/models/model.py
+++ b/src/models/model.py
@@ -34,6 +34,9 @@ class BERT_model(LightningModule):
         #softmax activation function
         self.softmax = nn.LogSoftmax(dim=1)
 
+        # Accuracy metric
+        self.Accuracy = torchmetrics.Accuracy()
+
     #define the forward pass
     def forward(self, sent_id, mask):
         #pass the inputs to the model
@@ -57,8 +60,7 @@ class BERT_model(LightningModule):
         logits = self(dat, mask)
         loss = F.nll_loss(logits, label)
         # acc = FM.accuracy(logits, label)
-        acc_metric = torchmetrics.Accuracy()
-        acc = acc_metric(logits.argmax(dim=1), label)
+        acc = self.Accuracy(logits.argmax(dim=1), label)
         self.log("train_Loss",
                  loss,
                  on_step=True,
@@ -78,8 +80,7 @@ class BERT_model(LightningModule):
         dat, mask, label = batch
         logits = self(dat, mask)
         loss = F.nll_loss(logits, label)
-        acc_metric = torchmetrics.Accuracy()
-        acc = acc_metric(logits.argmax(dim=1), label)
+        acc = self.Accuracy(logits.argmax(dim=1), label)
         self.log("val_loss",
                  loss,
                  on_step=True,


### PR DESCRIPTION
https://torchmetrics.readthedocs.io/en/latest/pages/overview.html#metrics-and-devices

_However, when properly defined inside a Module or LightningModule the metric will be be automatically move to the same device as the the module when using .to(device). Being properly defined means that the metric is correctly identified as a child module of the model (check .children() attribute of the model)._ 

I.e. it was not properly defined 